### PR TITLE
Introduce number of release to create

### DIFF
--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -4,12 +4,11 @@ set -e
 trap 'echo "******* FAILED *******" 1>&2' ERR
 
 SCRIPT_DIR=$(dirname $(readlink -f $0))
-INSTALL_DIR1=$(readlink -f $SCRIPT_DIR/../test_release_node1)
-INSTALL_DIR2=$(readlink -f $SCRIPT_DIR/../test_release_node2)
 
 UPGRADE=0
 INSTALL=0
 PREPARE=0
+NB_OF_RELEASES=0
 export MIX_ENV=dev
 
 usage() {
@@ -18,16 +17,26 @@ usage() {
   echo " Create a test release Archethic node binary"
   echo ""
   echo "  " release.sh -i "       Create and install release"
+  echo "  " release.sh -p "       Prepare the release for hot reload"
   echo "  " release.sh -u "       Upgrade the release"
+  echo "  " release.sh -n "       Set the number of node to apply the command"
   echo "  " release.sh -h "       Print the help usage"
   echo ""
 }
 
-while getopts ":uiph" option; do
+while getopts ":uiphn:" option; do
   case "${option}" in
   u) UPGRADE=1 ;;
   p) PREPARE=1 ;;
   i) INSTALL=1 ;;
+  n) 
+    if [[ ${OPTARG} =~ ^[0-9]+$ ]]; then
+      NB_OF_RELEASES=${OPTARG}
+    else
+      usage
+      exit 1
+    fi
+    ;;
   h)
     usage
     exit 0
@@ -40,71 +49,104 @@ while getopts ":uiph" option; do
 done
 shift $((OPTIND - 1))
 
+if [[ $NB_OF_RELEASES = 0 ]]; then
+  NB_OF_RELEASES=2
+fi
+
 # For every commands:
 cd $SCRIPT_DIR/..
 
 VERSION=$(grep 'version:' mix.exs | cut -d '"' -f2)
 echo ""
 echo "Version: ${VERSION}"
-echo "Installation dir node1: ${INSTALL_DIR1}"
-echo "Installation dir node2: ${INSTALL_DIR2}"
+
+for (( i=1; i<=$NB_OF_RELEASES; i++ )); do
+  INSTALL_DIR=$(readlink -f $SCRIPT_DIR/../test_release_node$i)
+  echo "Installation dir node $i: ${INSTALL_DIR}"
+done
+
+build_deps() {
+  # Install updated versions of hex/rebar
+  mix local.rebar --force
+  mix local.hex --if-missing --force
+
+  # Fetch deps and compile
+  mix deps.get
+
+  # Builds WEB assets in production mode
+  npm --prefix ./assets ci --progress=false --no-audit --loglevel=error
+  mix assets.saas
+  mix assets.deploy
+}
+
+update_tar_node_name() {
+  PWD=$(pwd)
+  DIR=$1
+  VERSION=$2
+  INDEX=$3
+
+  cd $DIR/releases/$VERSION
+  gunzip archethic_node.tar.gz
+  tar -xf archethic_node.tar releases/$VERSION/vm.args
+  sed -i "s/archethic_node/archethic_node$INDEX/g" releases/$VERSION/vm.args
+  tar -uf archethic_node.tar releases/$VERSION/vm.args
+  gzip archethic_node.tar
+  rm -r releases
+
+  cd $PWD
+}
 
 # Split commands logic
 if [ $UPGRADE == 1 ]; then
   echo "Running the upgrade"
-  $INSTALL_DIR1/bin/archethic_node upgrade $VERSION &
-  $INSTALL_DIR2/bin/archethic_node upgrade $VERSION &
-  exit
-fi
 
-# Install updated versions of hex/rebar
-mix local.rebar --force
-mix local.hex --if-missing --force
+  for (( i=1; i<=$NB_OF_RELEASES; i++ )); do
+    INSTALL_DIR=$(readlink -f $SCRIPT_DIR/../test_release_node$i)
+    $INSTALL_DIR/bin/archethic_node upgrade $VERSION &
+  done
 
-# Fetch deps and compile
-mix deps.get
-
-# Builds WEB assets in production mode
-npm --prefix ./assets ci --progress=false --no-audit --loglevel=error
-mix assets.saas
-mix assets.deploy
-
-# Create a release folder for each nodes
-mkdir -p $INSTALL_DIR1
-mkdir -p $INSTALL_DIR2
-
-if [ $PREPARE == 1 ]; then
+  wait
+elif [ $PREPARE == 1 ]; then
   echo "Building the upgrade release"
+
+  build_deps
+
   mix distillery.release --upgrade
 
   # cp the .tar.gz for distillery
-  mkdir -p $INSTALL_DIR1/releases/$VERSION
-  mkdir -p $INSTALL_DIR2/releases/$VERSION
-  cp _build/dev/rel/archethic_node/releases/$VERSION/archethic_node.tar.gz $INSTALL_DIR1/releases/$VERSION/archethic_node.tar.gz
-  cp _build/dev/rel/archethic_node/releases/$VERSION/archethic_node.tar.gz $INSTALL_DIR2/releases/$VERSION/archethic_node.tar.gz
+  echo "Copy release on $NB_OF_RELEASES release dir"
+  for (( i=1; i<=$NB_OF_RELEASES; i++ )); do
+    INSTALL_DIR=$(readlink -f $SCRIPT_DIR/../test_release_node$i)
+    mkdir -p $INSTALL_DIR/releases/$VERSION
+    cp _build/dev/rel/archethic_node/releases/$VERSION/archethic_node.tar.gz $INSTALL_DIR/releases/$VERSION/archethic_node.tar.gz
+    update_tar_node_name $INSTALL_DIR $VERSION $i &
+  done
 
-  # but we unpack them ourselves to avoid distillery skipping unpack
-  tar -xf _build/dev/rel/archethic_node/releases/$VERSION/archethic_node.tar.gz -C $INSTALL_DIR1
-  tar -xf _build/dev/rel/archethic_node/releases/$VERSION/archethic_node.tar.gz -C $INSTALL_DIR2
-
-  # update node2 name
-  sed -i 's/archethic_node/archethic_node2/g' $INSTALL_DIR2/releases/$VERSION/vm.args
+  wait
 
   echo "Release has been prepared"
   echo "Next step is to upgrade the running node: ./scripts/test-release.sh -u"
 elif [ $INSTALL == 1 ]; then
   echo "Building the release"
+
+  build_deps
+
   # create the release
   mix distillery.release
 
-  # unpack it
-  tar -xf _build/dev/rel/archethic_node/releases/$VERSION/archethic_node.tar.gz -C $INSTALL_DIR1
-  tar -xf _build/dev/rel/archethic_node/releases/$VERSION/archethic_node.tar.gz -C $INSTALL_DIR2
-
-  # update node2 name
-  sed -i 's/archethic_node/archethic_node2/g' $INSTALL_DIR2/releases/$VERSION/vm.args
+  # Create a release folder for each nodes
+  echo "Create release dir for $NB_OF_RELEASES nodes"
+  for (( i=1; i<=$NB_OF_RELEASES; i++ )); do
+    INSTALL_DIR=$(readlink -f $SCRIPT_DIR/../test_release_node$i)
+    mkdir -p $INSTALL_DIR
+    tar -xzf _build/dev/rel/archethic_node/releases/$VERSION/archethic_node.tar.gz -C $INSTALL_DIR
+    # Update node name
+    sed -i "s/archethic_node/archethic_node$i/g" $INSTALL_DIR/releases/$VERSION/vm.args
+  done
 
   echo "Release has been installed"
   echo "To run the release: ./test_release/bin/archethic_node console"
   echo "To test the upgrade, change git branch, update mix.exs version and run ./script/test-release.sh -p to prepare release then ./script/test-release.sh -u to run the upgrade"
 fi
+
+exit 0


### PR DESCRIPTION
Update tar over unpacking release

# Description

Introduce new option `-n` to set the number of release

Also update only the vm.args in the tar file when preparing a release of unpacking the full release

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
